### PR TITLE
Add Ubuntu theme

### DIFF
--- a/themes/Ubuntu.js
+++ b/themes/Ubuntu.js
@@ -1,0 +1,4 @@
+t.prefs_.set('color-palette-overrides',["#36342e", "#0000cc", "#069a4e", "#00a0c4", "#a46534", "#7b5075", "#9a9806", "#cfd7d3", "#535755", "#2929ef", "#34e28a", "#4fe9fc", "#cf9f72", "#a87fad", "#e2e234", "#eceeee"]);
+t.prefs_.set('foreground-color', "#eceeee");
+t.prefs_.set('background-color', "#240a30");
+t.prefs_.set('cursor-color', 'rgba(187,187,187,0.5)');


### PR DESCRIPTION
Ubuntu theme is shown in the README screenshots, but the theme itself is missing. This adds the theme file.

Exported from https://github.com/mbadolato/iTerm2-Color-Schemes/blob/master/schemes/Ubuntu.itermcolors using this script https://gist.github.com/atav32/7c1cfe3e06bd4c87349930995b61c011