### PR TITLE
Adding Atelier Cave theme

### DIFF
--- a/themes/AtelierCave.js
+++ b/themes/AtelierCave.js
@@ -1,0 +1,4 @@
+t.prefs_.set('color-palette-overrides',["#19171c", "#be4678", "#2a9292", "#a06e3b", "#576ddb", "#955ae7", "#398bc6", "#8b8792", "#655f6d", "#aa573c", "#26232a", "#585260", "#7e7887", "#e2dfe7", "#bf40bf", "#efecf4"]);
+t.prefs_.set('foreground-color', "#8b8792");
+t.prefs_.set('background-color', "#19171c");
+t.prefs_.set('cursor-color', 'rgba(139,135,146,0.5)');


### PR DESCRIPTION
I created the Atelier Cave theme using the official theme and terminal colors specified here:

https://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave/
https://github.com/cassidoo/vim-up/blob/master/iterm-colors/base16-ateliercave.dark.itermcolors